### PR TITLE
Add a note for omission of the turn header in action description

### DIFF
--- a/docs/guides/binmat/binlog.mdx
+++ b/docs/guides/binmat/binlog.mdx
@@ -25,6 +25,8 @@ If multiple players on a given role are present, their actions are presented one
 
 ## Actions
 
+_(( %AIn this section, the turn header is omitted for simplicity.%))_
+
 Most actions, such as drawing cards, playing cards or discarding cards only produce a single log line:
 > (( a0 d5 / %D8!% ha0 ))
 


### PR DESCRIPTION
Small clarification, but might help reduce confusion.